### PR TITLE
Highlights from Solr & Alternative Fields for display

### DIFF
--- a/jquery.facetview.js
+++ b/jquery.facetview.js
@@ -192,8 +192,7 @@ result_display
 A display template for search results. It is a list of lists.
 Each list specifies a line. Within each list, specify the contents of the line using objects to describe 
 them. Each content piece should pertain to a particular "field" or "highlight_field" of the result set.
-For each "field" you can specify what to show "pre" and "post" the given field.
-For all "highlight_field" , "highlight_pre" and "highlight_pre" general options are used.
+For each "field" or "highlight_field", you can specify what to show "pre" and "post" the given field.
 
 display_images
 --------------
@@ -406,7 +405,9 @@ search box - the end user will not know they are happening.
                 ],
                 [
                     {
-                    	"highlight_field": "text"
+                    	"pre": "<span class='highlightings'>",
+                    	"highlight_field": "text",
+                    	"post": "</span>"
                     }
                 ]
             ];

--- a/jquery.facetview.js
+++ b/jquery.facetview.js
@@ -338,7 +338,8 @@ search box - the end user will not know they are happening.
 
         // a big default value (pulled into options below)
         // demonstrates how to specify an output style based on the fields that can be found in the result object
-        // where a specified field is not found, the pre and post for it are just ignored
+        // where a specified field is not found, the 'alternative_field' will be used
+        // if the field and alternative_field are both not found, pre and post are just ignored
         var resdisplay = [
                 [
                     {
@@ -354,6 +355,7 @@ search box - the end user will not know they are happening.
                     {
                         "pre": "<strong>",
                         "field": "title",
+                        "alternative_field": "booktitle",
                         "post": "</strong>"
                     }
                 ],
@@ -851,7 +853,11 @@ search box - the end user will not know they are happening.
                 line = "";
                 for ( var object = 0; object < display[lineitem].length; object++ ) {
                     var thekey = display[lineitem][object]['field'];
+                    var alternative_key = display[lineitem][object]['alternative_field'];
                     var thevalue = getvalue(record, thekey);
+                    if (!(thevalue && thevalue.toString().length)) {
+                        thevalue = getvalue(record, alternative_key);
+                    }
                     if (thevalue && thevalue.toString().length) {
                         display[lineitem][object]['pre']
                             ? line += display[lineitem][object]['pre'] : false;

--- a/jquery.facetview.js
+++ b/jquery.facetview.js
@@ -444,7 +444,10 @@ search box - the end user will not know they are happening.
             "linkify": true,
             "default_operator": "OR",
             "default_freetext_fuzzify": false,
-
+            "solr_doc_id": "id",
+            "highlight_fields": [],
+            "highlight_pre": "<em>",
+            "highlight_post": "</em>"
         };
 
 
@@ -741,6 +744,7 @@ search box - the end user will not know they are happening.
             resultobj["start"] = "";
             resultobj["found"] = "";
             resultobj["facets"] = new Object();
+            resultobj["highlighting"] = new Object();
             if ( options.search_index == "elasticsearch" ) {
 
                 for ( var item = 0; item < dataobj.hits.hits.length; item++ ) {
@@ -769,6 +773,7 @@ search box - the end user will not know they are happening.
                 resultobj["records"] = dataobj.response.docs;
                 resultobj["start"] = dataobj.response.start;
                 resultobj["found"] = dataobj.response.numFound;
+                resultobj["highlighting"] = dataobj.highlighting;
                 if (dataobj.facet_counts) {
                     for (var item in dataobj.facet_counts.facet_fields) {
                         var facetsobj = new Object();
@@ -837,6 +842,7 @@ search box - the end user will not know they are happening.
         var buildrecord = function(index) {
             var record = options.data['records'][index];
             var result = options.resultwrap_start;
+            var highlights = options.data['highlighting'][record[options.solr_doc_id]];
             // add first image where available
             if (options.display_images) {
                 var recstr = JSON.stringify(record);
@@ -854,9 +860,18 @@ search box - the end user will not know they are happening.
                 for ( var object = 0; object < display[lineitem].length; object++ ) {
                     var thekey = display[lineitem][object]['field'];
                     var alternative_key = display[lineitem][object]['alternative_field'];
-                    var thevalue = getvalue(record, thekey);
-                    if (!(thevalue && thevalue.toString().length)) {
-                        thevalue = getvalue(record, alternative_key);
+                    var thevalue;
+                    if (display[lineitem][object].hasOwnProperty('field')) {
+                        var thekey = display[lineitem][object]['field'];                    
+                        var alternative_key = display[lineitem][object]['alternative_field'];
+                        thevalue = getvalue(record, thekey);
+                        if (!(thevalue && thevalue.toString().length)) {
+                            thevalue = getvalue(record, alternative_key);
+                        }
+                    }
+                    else if (display[lineitem][object].hasOwnProperty('highlight_field')){
+                        var highlightkey = display[lineitem][object]['highlight_field'];
+                        thevalue = highlights[highlightkey];
                     }
                     if (thevalue && thevalue.toString().length) {
                         display[lineitem][object]['pre']
@@ -1179,8 +1194,15 @@ search box - the end user will not know they are happening.
             if ( options.facets.length > 0 ) {
                 urlfilters += "facet=on&";
             }
+            // highlighting params                                                          ////////hl////////
+            var highlighting_params = "";
+            if (options.highlight_fields.length > 0) {
+                highlighting_params += "hl=true&hl.fl=" + options.highlight_fields.join(",");
+                highlighting_params += "&hl.simple.pre=" + options.highlight_pre;
+                highlighting_params += "&hl.simple.post=" + options.highlight_post + "&";
+            }
             // build starting URL
-            var theurl = urlparams + pageparams + urlfilters;
+            var theurl = urlparams + pageparams + urlfilters + highlighting_params;
             // add default query values
             // build the query, starting with default values
             var query = "";

--- a/jquery.facetview.js
+++ b/jquery.facetview.js
@@ -191,8 +191,9 @@ result_display
 --------------
 A display template for search results. It is a list of lists.
 Each list specifies a line. Within each list, specify the contents of the line using objects to describe 
-them. Each content piece should pertain to a particular "field" of the result set, and should specify what 
-to show "pre" and "post" the given field
+them. Each content piece should pertain to a particular "field" or "highlight_field" of the result set.
+For each "field" you can specify what to show "pre" and "post" the given field.
+For all "highlight_field" , "highlight_pre" and "highlight_pre" general options are used.
 
 display_images
 --------------
@@ -220,6 +221,18 @@ Set to false to wait for user input before issuing the first search.
 fields
 ------
 A list of which fields the index should return in result objects (by default elasticsearch returns them all).
+
+highlight_fields
+----------------
+A list of fields used for highlighting (passed to solr query as the value of hl.fields)
+
+highlight_pre
+-------------
+HTML markup to inject before highlight fields (passed to solr query as the value of hl.simple.pre)
+
+highlight_post
+-------------
+HTML markup to inject after highlight fields (passed to solr query as the value of hl.simple.post)
 
 partial_fields
 --------------
@@ -390,7 +403,12 @@ search box - the end user will not know they are happening.
                     {
                         "field": "link.url"
                     }
-                ]    
+                ],
+                [
+                    {
+                    	"highlight_field": "text"
+                    }
+                ]
             ];
 
         // specify the defaults
@@ -446,8 +464,8 @@ search box - the end user will not know they are happening.
             "default_freetext_fuzzify": false,
             "solr_doc_id": "id",
             "highlight_fields": [],
-            "highlight_pre": "<em>",
-            "highlight_post": "</em>"
+            "highlight_pre": "<mark>",
+            "highlight_post": "</mark>"
         };
 
 


### PR DESCRIPTION
### Alternative Fields

alternative_field' can be added to result_display so that it is used if the specified 'field' does not exist.

e.g. assume we are displaying the 'title' of the results but for those results with no title, we would like to display the file name instead:

``` javascript
result_display: [
                    [
                        {
                            "pre": "<h4>",
                            "field": "title",
                            "alternative_field": "file_name",
                            "post": "</h4>"
                        }
                    ]
                ]
```
### Highlightings from Solr

First, you should specify the following facetview options:

``` javascript
{
    solr_doc_id: "id",
    highlight_fields: ["text"],            // you can specify more than one
    highlight_pre: "<mark>",
    highlight_post: "</mark>"
}
```

Then, you can display the highlightings by adding them to result_display. Check out this example:

``` javascript
result_display: [
                    [
                        {
                            pre: "<a target='_blank' href='",
                            field: "url",
                            post: "'>"

                        },
                        {
                            pre: "<h4>",
                            field: "title",
                            post: "</h4></a>"
                        },
                    ],
                    [
                        {
                            pre: "<span class='text_highlightings'>",
                            highlight_field: "text",
                            post: "</span>"
                        }
                    ]
                ]
```
